### PR TITLE
 Fix: Fallback to device when l3_device is missing in network interface status

### DIFF
--- a/nikki/files/ucode/hijack.ut
+++ b/nikki/files/ucode/hijack.ut
@@ -50,7 +50,8 @@
 	const lan_inbound_interface = uci_array(uci.get('nikki', 'proxy', 'lan_inbound_interface'));
 	const lan_inbound_device = [];
 	for (let interface in lan_inbound_interface) {
-		const device = ubus.call('network.interface', 'status', {'interface': interface})?.l3_device ?? '';
+		const status = ubus.call('network.interface', 'status', { 'interface': interface }) || {};
+		const device = status.l3_device ?? status.device ?? '';
 		if (device != '') {
 			push(lan_inbound_device, device);
 		}

--- a/nikki/files/ucode/mixin.uc
+++ b/nikki/files/ucode/mixin.uc
@@ -10,11 +10,14 @@ const uci = cursor();
 const ubus = connect();
 
 const config = {};
+const status = ubus.call('network.interface', 'status', {
+        'interface': uci.get('nikki', 'mixin', 'outbound_interface')
+    });
 
 config['log-level'] = uci.get('nikki', 'mixin', 'log_level');
 config['mode'] = uci.get('nikki', 'mixin', 'mode');
 config['find-process-mode'] = uci.get('nikki', 'mixin', 'match_process');
-config['interface-name'] = ubus.call('network.interface', 'status', {'interface': uci.get('nikki', 'mixin', 'outbound_interface')})?.l3_device;
+config['interface-name'] = status?.l3_device ?? status?.device ?? '';
 config['ipv6'] = uci_bool(uci.get('nikki', 'mixin', 'ipv6'));
 config['unified-delay'] = uci_bool(uci.get('nikki', 'mixin', 'unify_delay'));
 config['tcp-concurrent'] = uci_bool(uci.get('nikki', 'mixin', 'tcp_concurrent'));


### PR DESCRIPTION
This PR fixes an issue where Docker traffic was not being properly captured by the firewall rules.