### PR TITLE
Add GO_PKG_BUILD_PKG variable to Makefile

### DIFF
--- a/mihomo-alpha/Makefile
+++ b/mihomo-alpha/Makefile
@@ -21,6 +21,7 @@ PKG_BUILD_VERSION:=alpha-c59c99a0
 PKG_BUILD_TIME:=$(shell date -u -Iseconds)
 
 GO_PKG:=github.com/metacubex/mihomo
+GO_PKG_BUILD_PKG:=github.com/metacubex/mihomo
 GO_PKG_LDFLAGS_X:=$(GO_PKG)/constant.Version=$(PKG_BUILD_VERSION) $(GO_PKG)/constant.BuildTime=$(PKG_BUILD_TIME)
 GO_PKG_TAGS:=with_gvisor
 GO_PKG_INSTALL_BIN_PATH:=/usr/libexec

--- a/mihomo-meta/Makefile
+++ b/mihomo-meta/Makefile
@@ -21,6 +21,7 @@ PKG_BUILD_VERSION:=v1.19.24
 PKG_BUILD_TIME:=$(shell date -u -Iseconds)
 
 GO_PKG:=github.com/metacubex/mihomo
+GO_PKG_BUILD_PKG:=$(GO_PKG)
 GO_PKG_LDFLAGS_X:=$(GO_PKG)/constant.Version=$(PKG_BUILD_VERSION) $(GO_PKG)/constant.BuildTime=$(PKG_BUILD_TIME)
 GO_PKG_TAGS:=with_gvisor
 GO_PKG_INSTALL_BIN_PATH:=/usr/libexec

--- a/mihomo-meta/Makefile
+++ b/mihomo-meta/Makefile
@@ -21,7 +21,7 @@ PKG_BUILD_VERSION:=v1.19.24
 PKG_BUILD_TIME:=$(shell date -u -Iseconds)
 
 GO_PKG:=github.com/metacubex/mihomo
-GO_PKG_BUILD_PKG:=$(GO_PKG)
+GO_PKG_BUILD_PKG:=github.com/metacubex/mihomo
 GO_PKG_LDFLAGS_X:=$(GO_PKG)/constant.Version=$(PKG_BUILD_VERSION) $(GO_PKG)/constant.BuildTime=$(PKG_BUILD_TIME)
 GO_PKG_TAGS:=with_gvisor
 GO_PKG_INSTALL_BIN_PATH:=/usr/libexec


### PR DESCRIPTION
Fix no Go files in .go_work/build error on newer OpenWrt build environments (like OpenWrt 24.x/25.x) by explicitly defining GO_PKG_BUILD_PKG.

在immortal-openwrt-25.12分支中，缺少go路径会导致编译找不到而失败