### PR TITLE
Fix nft hijack failure when WireGuard ingress is enabled with MAC ACLs

### DIFF
--- a/nikki/files/ucode/hijack.ut
+++ b/nikki/files/ucode/hijack.ut
@@ -383,7 +383,7 @@ table inet nikki {
 		{% endif %}
 		{% endif %}
 		{% if (length(access_control['mac']) > 0): %}
-		meta nfproto @dns_hijack_nfproto meta l4proto { tcp, udp } ether saddr { {{ join(', ', access_control['mac']) }} } th dport 53 counter {% if (access_control['dns']): %} redirect to :{{ dns_port }} {% else %} return {% endif %} #
+		meta nfproto @dns_hijack_nfproto meta l4proto { tcp, udp } meta iiftype ether ether saddr { {{ join(', ', access_control['mac']) }} } th dport 53 counter {% if (access_control['dns']): %} redirect to :{{ dns_port }} {% else %} return {% endif %} #
 		{% endif %}
 		{% endif %}
 		{% endfor %}
@@ -406,7 +406,7 @@ table inet nikki {
 		{% endif %}
 		{% endif %}
 		{% if (length(access_control['mac']) > 0): %}
-		meta nfproto @proxy_nfproto meta l4proto tcp ether saddr { {{ join(', ', access_control['mac']) }} } counter {% if (access_control['proxy']): %} redirect to :{{ redir_port }} {% else %} return {% endif %} #
+		meta nfproto @proxy_nfproto meta l4proto tcp meta iiftype ether ether saddr { {{ join(', ', access_control['mac']) }} } counter {% if (access_control['proxy']): %} redirect to :{{ redir_port }} {% else %} return {% endif %} #
 		{% endif %}
 		{% endif %}
 		{% endfor %}
@@ -444,9 +444,9 @@ table inet nikki {
 		{% endif %}
 		{% if (length(access_control['mac']) > 0): %}
 		{% if (access_control['dns']): %}
-		meta nfproto @dns_hijack_nfproto meta l4proto { tcp, udp } ether saddr { {{ join(', ', access_control['mac']) }} } th dport 53 counter return #
+		meta nfproto @dns_hijack_nfproto meta l4proto { tcp, udp } meta iiftype ether ether saddr { {{ join(', ', access_control['mac']) }} } th dport 53 counter return #
 		{% endif %}
-		meta nfproto @proxy_nfproto meta l4proto { tcp, udp } ether saddr { {{ join(', ', access_control['mac']) }} } {% if (access_control['proxy']): %} meta mark set meta mark & {{ tproxy_fw_umask }} | {{ tproxy_fw_mark }} tproxy to :{{ tproxy_port }} counter accept {% else %} counter return {% endif %} #
+		meta nfproto @proxy_nfproto meta l4proto { tcp, udp } meta iiftype ether ether saddr { {{ join(', ', access_control['mac']) }} } {% if (access_control['proxy']): %} meta mark set meta mark & {{ tproxy_fw_umask }} | {{ tproxy_fw_mark }} tproxy to :{{ tproxy_port }} counter accept {% else %} counter return {% endif %} #
 		{% endif %}
 		{% endif %}
 		{% endfor %}
@@ -484,9 +484,9 @@ table inet nikki {
 		{% endif %}
 		{% if (length(access_control['mac']) > 0): %}
 		{% if (access_control['dns']): %}
-		meta nfproto @dns_hijack_nfproto meta l4proto { tcp, udp } ether saddr { {{ join(', ', access_control['mac']) }} } th dport 53 counter return #
+		meta nfproto @dns_hijack_nfproto meta l4proto { tcp, udp } meta iiftype ether ether saddr { {{ join(', ', access_control['mac']) }} } th dport 53 counter return #
 		{% endif %}
-		meta nfproto @proxy_nfproto meta l4proto { tcp, udp } ether saddr { {{ join(', ', access_control['mac']) }} } {% if (access_control['proxy']): %} meta mark set meta mark & {{ tun_fw_umask }} | {{ tun_fw_mark }} counter accept {% else %} counter return {% endif %} #
+		meta nfproto @proxy_nfproto meta l4proto { tcp, udp } meta iiftype ether ether saddr { {{ join(', ', access_control['mac']) }} } {% if (access_control['proxy']): %} meta mark set meta mark & {{ tun_fw_umask }} | {{ tun_fw_mark }} counter accept {% else %} counter return {% endif %} #
 		{% endif %}
 		{% endif %}
 		{% endfor %}


### PR DESCRIPTION
## Summary
- add `meta iiftype ether` before MAC-based `ether saddr` ACL matches in the hijack nft template
- keep MAC access-control rules from being evaluated on non-Ethernet ingress devices such as WireGuard/TUN interfaces

## Why
When `proxy.lan_inbound_interface` includes both a bridge LAN device and a WireGuard interface, Nikki still renders MAC-based LAN access-control rules. Those rules should only apply to Ethernet ingress packets; WireGuard packets do not have an Ethernet source MAC.

Guarding the `ether saddr` matches with `meta iiftype ether` preserves existing MAC ACL behavior for LAN clients while allowing the later catch-all DNS hijack / tproxy rules to handle WireGuard traffic.

## Validation
Tested on an OpenWrt router running Nikki with:

```sh
utpl -S /etc/nikki/ucode/hijack.ut >/tmp/hijack.pr.nft
nft -c -f /tmp/hijack.pr.nft
```

Also verified the rendered rules load successfully with `lan_inbound_interface='lan' 'wg'` and MAC-based LAN access-control entries present.