### PR TITLE
Update nikki.init

### DIFF
--- a/nikki/files/nikki.init
+++ b/nikki/files/nikki.init
@@ -148,6 +148,7 @@ start_service() {
 		log "App" "Exit."
 		return
 	fi
+	yq -M -i 'explode(.)' "$RUN_PROFILE_PATH"
 	# mixin
 	if [ "$core_only" = 0 ]; then
 		log "Mixin" "Mixin config."


### PR DESCRIPTION
Add yq explode(.) after cp profile to RUN_PROFILE_PATH to expand YAML anchors before mixin processing, enabling rule-anchor syntax in profile files.