### PR TITLE
fix: auto add default fallback rule for lan/router access control

### DIFF
--- a/nikki/files/ucode/hijack.ut
+++ b/nikki/files/ucode/hijack.ut
@@ -90,6 +90,12 @@
 		}
 	});
 
+	const has_router_default_rule = length(filter(router_access_control, (x) =>
+		length(x['user']) == 0 &&
+		length(x['group']) == 0 &&
+		length(x['cgroup']) == 0
+	)) > 0;
+
 	const lan_proxy = uci_bool(uci.get('nikki', 'proxy', 'lan_proxy'));
 	const lan_inbound_interface = uci_array(uci.get('nikki', 'proxy', 'lan_inbound_interface'));
 	const lan_inbound_device = [];
@@ -112,6 +118,12 @@
 			push(lan_access_control, access_control);
 		}
 	});
+
+	const has_lan_default_rule = length(filter(lan_access_control, (x) =>
+		length(x['ip']) == 0 &&
+		length(x['ip6']) == 0 &&
+		length(x['mac']) == 0
+	)) > 0;
 
 	const reserved_ip = uci_array(uci.get('nikki', 'proxy', 'reserved_ip'));
 	const reserved_ip6 = uci_array(uci.get('nikki', 'proxy', 'reserved_ip6'));
@@ -273,6 +285,9 @@ table inet nikki {
 		{% endif %}
 		{% endif %}
 		{% endfor %}
+		{% if (!has_router_default_rule): %}
+		meta nfproto @dns_hijack_nfproto meta l4proto { tcp, udp } th dport 53 counter redirect to :{{ dns_port }}
+		{% endif %}
 	}
 
 	{% if (tcp_mode == 'redirect'): %}
@@ -294,6 +309,9 @@ table inet nikki {
 		{% endif %}
 		{% endif %}
 		{% endfor %}
+		{% if (!has_router_default_rule): %}
+		meta nfproto @proxy_nfproto meta l4proto tcp counter redirect to :{{ redir_port }}
+		{% endif %}
 	}
 	{% endif %}
 
@@ -328,6 +346,9 @@ table inet nikki {
 		{% endif %}
 		{% endif %}
 		{% endfor %}
+		{% if (!has_router_default_rule): %}
+		meta nfproto @proxy_nfproto meta l4proto { tcp, udp } meta mark set meta mark & {{ tproxy_fw_umask }} | {{ tproxy_fw_mark }} tproxy to :{{ tproxy_port }} counter accept
+		{% endif %}
 	}
 	{% endif %}
 
@@ -362,6 +383,9 @@ table inet nikki {
 		{% endif %}
 		{% endif %}
 		{% endfor %}
+		{% if (!has_router_default_rule): %}
+		meta nfproto @proxy_nfproto meta l4proto { tcp, udp } meta mark set meta mark & {{ tun_fw_umask }} | {{ tun_fw_mark }} counter accept
+		{% endif %}
 	}
 	{% endif %}
 	{% endif %}
@@ -387,6 +411,9 @@ table inet nikki {
 		{% endif %}
 		{% endif %}
 		{% endfor %}
+		{% if (!has_lan_default_rule): %}
+		meta nfproto @dns_hijack_nfproto meta l4proto { tcp, udp } th dport 53 counter redirect to :{{ dns_port }}
+		{% endif %}
 	}
 
 	{% if (tcp_mode == 'redirect'): %}
@@ -410,6 +437,9 @@ table inet nikki {
 		{% endif %}
 		{% endif %}
 		{% endfor %}
+		{% if (!has_lan_default_rule): %}
+		meta nfproto @proxy_nfproto meta l4proto tcp counter redirect to :{{ redir_port }}
+		{% endif %}
 	}
 	{% endif %}
 
@@ -450,6 +480,9 @@ table inet nikki {
 		{% endif %}
 		{% endif %}
 		{% endfor %}
+		{% if (!has_lan_default_rule): %}
+		meta nfproto @proxy_nfproto meta l4proto { tcp, udp } meta mark set meta mark & {{ tproxy_fw_umask }} | {{ tproxy_fw_mark }} tproxy to :{{ tproxy_port }} counter accept
+		{% endif %}
 	}
 	{% endif %}
 
@@ -490,6 +523,9 @@ table inet nikki {
 		{% endif %}
 		{% endif %}
 		{% endfor %}
+		{% if (!has_lan_default_rule): %}
+		meta nfproto @proxy_nfproto meta l4proto { tcp, udp } meta mark set meta mark & {{ tun_fw_umask }} | {{ tun_fw_mark }} counter accept
+		{% endif %}
 	}
 	{% endif %}
 	{% endif %}


### PR DESCRIPTION
When lan_access_control or router_access_control has no default rule
(a rule with empty ip/ip6/mac or user/group/cgroup), all traffic would
bypass the proxy, causing proxy to fail for all LAN clients.

This patch detects whether a default/fallback rule exists in the config.
If not, a fallback rule is automatically appended at the end of each
chain (lan_dns_hijack, lan_redirect, lan_tproxy, lan_tun,
router_dns_hijack, router_redirect, router_tproxy, router_tun),
ensuring all unmatched traffic is proxied by default.

Users now only need to configure exception rules (e.g. specific IPs
to bypass proxy) without manually adding an empty catch-all rule.
Existing configs with an explicit default rule are unaffected.