### PR TITLE
feat: allow custom HTTP request headers for subscription download

### DIFF
--- a/luci-app-nikki/htdocs/luci-static/resources/view/nikki/profile.js
+++ b/luci-app-nikki/htdocs/luci-static/resources/view/nikki/profile.js
@@ -78,6 +78,38 @@ return view.extend({
         o.value('clash.meta');
         o.value('mihomo');
 
+        o = s.option(form.DynamicList, 'header', _('HWID Headers'));
+        o.modalonly = true;
+        o.placeholder = 'x-hwid: 7Kq2mVt9XbLp4Ndc';
+        o.validate = function (section_id, value) {
+            if (!value) {
+                return true;
+            }
+            if (!/^[A-Za-z0-9-]+:[\x20-\x7E]*$/.test(value)) {
+                return _('Expected format: Name: value (printable ASCII only)');
+            }
+            const name = value.split(':')[0].toLowerCase();
+            const reserved = [
+                'connection', 'content-length', 'expect', 'host',
+                'proxy-authorization', 'proxy-connection', 'te', 'trailer',
+                'transfer-encoding', 'upgrade', 'user-agent'
+            ];
+            if (reserved.includes(name)) {
+                return _('This header is reserved and cannot be overridden');
+            }
+            const values = this.formvalue(section_id) ?? [];
+            let count = 0;
+            for (const item of values) {
+                if (item && item.split(':')[0].toLowerCase() === name) {
+                    count++;
+                }
+            }
+            if (count > 1) {
+                return _('Duplicate header name');
+            }
+            return true;
+        };
+
         o = s.option(form.ListValue, 'prefer', _('Prefer'));
         o.default = 'remote';
         o.modalonly = true;

--- a/luci-app-nikki/po/ru/nikki.po
+++ b/luci-app-nikki/po/ru/nikki.po
@@ -280,6 +280,10 @@ msgstr "Суффикс домена"
 msgid "Domain Name Wildcard"
 msgstr "Шаблон домена"
 
+#: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/profile.js:108
+msgid "Duplicate header name"
+msgstr "Повторяющееся имя заголовка"
+
 #: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/mixin.js:169
 msgid "Edit Authentications"
 msgstr "Редактировать учётные данные"
@@ -369,6 +373,10 @@ msgstr "Включить"
 #: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/app.js:173
 msgid "Environment Variable Config"
 msgstr "Переменные окружения"
+
+#: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/profile.js:89
+msgid "Expected format: Name: value (printable ASCII only)"
+msgstr "Ожидаемый формат: Имя: значение (только печатаемые символы ASCII)"
 
 #: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/profile.js:47
 msgid "Expire At"
@@ -499,6 +507,10 @@ msgstr "Группа"
 #: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/mixin.js:146
 msgid "HTTP Port"
 msgstr "Порт HTTP"
+
+#: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/profile.js:81
+msgid "HWID Headers"
+msgstr "HWID-заголовки"
 
 #: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/app.js:155
 msgid "Heap Size Hard Limit"
@@ -967,6 +979,10 @@ msgstr "Тайм-аут TUN"
 #: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/app.js:122
 msgid "Test Profile"
 msgstr "Проверить профиль"
+
+#: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/profile.js:98
+msgid "This header is reserved and cannot be overridden"
+msgstr "Этот заголовок зарезервирован и не может быть переопределён"
 
 #: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/profile.js:42
 msgid "Total"

--- a/luci-app-nikki/po/templates/nikki.pot
+++ b/luci-app-nikki/po/templates/nikki.pot
@@ -273,6 +273,10 @@ msgstr ""
 msgid "Domain Name Wildcard"
 msgstr ""
 
+#: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/profile.js:108
+msgid "Duplicate header name"
+msgstr ""
+
 #: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/mixin.js:169
 msgid "Edit Authentications"
 msgstr ""
@@ -361,6 +365,10 @@ msgstr ""
 
 #: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/app.js:173
 msgid "Environment Variable Config"
+msgstr ""
+
+#: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/profile.js:89
+msgid "Expected format: Name: value (printable ASCII only)"
 msgstr ""
 
 #: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/profile.js:47
@@ -491,6 +499,10 @@ msgstr ""
 
 #: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/mixin.js:146
 msgid "HTTP Port"
+msgstr ""
+
+#: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/profile.js:81
+msgid "HWID Headers"
 msgstr ""
 
 #: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/app.js:155
@@ -959,6 +971,10 @@ msgstr ""
 
 #: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/app.js:122
 msgid "Test Profile"
+msgstr ""
+
+#: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/profile.js:98
+msgid "This header is reserved and cannot be overridden"
 msgstr ""
 
 #: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/profile.js:42

--- a/luci-app-nikki/po/zh_Hans/nikki.po
+++ b/luci-app-nikki/po/zh_Hans/nikki.po
@@ -280,6 +280,10 @@ msgstr "域名（后缀）"
 msgid "Domain Name Wildcard"
 msgstr "域名（通配符）"
 
+#: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/profile.js:108
+msgid "Duplicate header name"
+msgstr "请求头名称重复"
+
 #: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/mixin.js:169
 msgid "Edit Authentications"
 msgstr "编辑身份验证"
@@ -369,6 +373,10 @@ msgstr "启用"
 #: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/app.js:173
 msgid "Environment Variable Config"
 msgstr "环境变量配置"
+
+#: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/profile.js:89
+msgid "Expected format: Name: value (printable ASCII only)"
+msgstr "格式应为：名称: 值（仅限可打印 ASCII 字符）"
 
 #: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/profile.js:47
 msgid "Expire At"
@@ -499,6 +507,10 @@ msgstr "用户组"
 #: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/mixin.js:146
 msgid "HTTP Port"
 msgstr "HTTP 端口"
+
+#: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/profile.js:81
+msgid "HWID Headers"
+msgstr "HWID 请求头"
 
 #: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/app.js:155
 msgid "Heap Size Hard Limit"
@@ -967,6 +979,10 @@ msgstr "TUN 等待超时"
 #: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/app.js:122
 msgid "Test Profile"
 msgstr "检查配置文件"
+
+#: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/profile.js:98
+msgid "This header is reserved and cannot be overridden"
+msgstr "该请求头为保留项，无法覆盖"
 
 #: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/profile.js:42
 msgid "Total"

--- a/luci-app-nikki/po/zh_Hant/nikki.po
+++ b/luci-app-nikki/po/zh_Hant/nikki.po
@@ -280,6 +280,10 @@ msgstr "網域名稱（後綴）"
 msgid "Domain Name Wildcard"
 msgstr "網域名稱（通配符）"
 
+#: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/profile.js:108
+msgid "Duplicate header name"
+msgstr "請求標頭名稱重複"
+
 #: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/mixin.js:169
 msgid "Edit Authentications"
 msgstr "編輯身分驗證"
@@ -369,6 +373,10 @@ msgstr "啟用"
 #: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/app.js:173
 msgid "Environment Variable Config"
 msgstr "環境變數設定"
+
+#: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/profile.js:89
+msgid "Expected format: Name: value (printable ASCII only)"
+msgstr "格式應為：名稱: 值（僅限可列印 ASCII 字元）"
 
 #: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/profile.js:47
 msgid "Expire At"
@@ -499,6 +507,10 @@ msgstr "使用者群組"
 #: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/mixin.js:146
 msgid "HTTP Port"
 msgstr "HTTP 埠"
+
+#: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/profile.js:81
+msgid "HWID Headers"
+msgstr "HWID 請求標頭"
 
 #: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/app.js:155
 msgid "Heap Size Hard Limit"
@@ -967,6 +979,10 @@ msgstr "TUN 等待超時"
 #: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/app.js:122
 msgid "Test Profile"
 msgstr "檢查設定檔"
+
+#: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/profile.js:98
+msgid "This header is reserved and cannot be overridden"
+msgstr "此請求標頭為保留項目，無法覆寫"
 
 #: applications/luci-app-nikki/htdocs/luci-static/resources/view/nikki/profile.js:42
 msgid "Total"

--- a/nikki/files/nikki.init
+++ b/nikki/files/nikki.init
@@ -536,6 +536,36 @@ clear_logs() {
 	fi
 }
 
+append_subscription_request_header() {
+	if [ -z "$1" ]; then
+		return
+	fi
+	local header; header="$(printf '%s' "$1" | tr -d '\r\n')"
+	if [ "$header" != "$1" ]; then
+		log "Profile" "Skip request header containing line break."
+		return
+	fi
+	if ! printf '%s' "$header" | LC_ALL=C grep -q -E '^[A-Za-z0-9-]+:[ -~]*$'; then
+		log "Profile" "Skip invalid request header: ${header%%:*}"
+		return
+	fi
+	local name; name="$(printf '%s' "${header%%:*}" | tr 'A-Z' 'a-z')"
+	case "$name" in
+		host|content-length|transfer-encoding|connection|upgrade|expect|te|trailer|proxy-authorization|proxy-connection|user-agent)
+			log "Profile" "Skip reserved request header: $name"
+			return
+		;;
+	esac
+	if grep -qxF "$header" "$2" 2>/dev/null; then
+		return
+	fi
+	if grep -q -i -E "^$name:" "$2" 2>/dev/null; then
+		log "Profile" "Skip duplicate request header: $name"
+		return
+	fi
+	echo "$header" >> "$2"
+}
+
 update_subscription() {
 	local subscription_section; subscription_section="$1"
 	if [ -z "$subscription_section" ]; then
@@ -564,12 +594,21 @@ update_subscription() {
 	local subscription_info_header_tmpfile; subscription_info_header_tmpfile="$TEMP_DIR/$subscription_section.info.header"
 	local subscription_header_tmpfile; subscription_header_tmpfile="$TEMP_DIR/$subscription_section.header"
 	local subscription_tmpfile; subscription_tmpfile="$TEMP_DIR/$subscription_section.yaml"
+	local subscription_request_header_tmpfile; subscription_request_header_tmpfile="$TEMP_DIR/$subscription_section.request.header"
 	local subscription_info_file
 	local subscription_file; subscription_file="$SUBSCRIPTIONS_DIR/$subscription_section.yaml"
+	# build custom request headers
+	local subscription_request_header_arg=""
+	rm -f "$subscription_request_header_tmpfile"
+	( umask 077; : > "$subscription_request_header_tmpfile" )
+	config_list_foreach "$subscription_section" "header" append_subscription_request_header "$subscription_request_header_tmpfile"
+	if [ -s "$subscription_request_header_tmpfile" ]; then
+		subscription_request_header_arg="-H @$subscription_request_header_tmpfile"
+	fi
 	# fetch subscription info
 	if [ -n "$subscription_info_url" ]; then
 		log "Profile" "Fetch subscription info."
-		if curl -s -f -m 120 --connect-timeout 15 --retry 3 -L -X GET -A "$subscription_user_agent" -D "$subscription_info_header_tmpfile" "$subscription_info_url" > /dev/null 2>&1; then
+		if curl -s -f -m 120 --connect-timeout 15 --retry 3 -L -X GET -A "$subscription_user_agent" $subscription_request_header_arg -D "$subscription_info_header_tmpfile" "$subscription_info_url" > /dev/null 2>&1; then
 			if [ ! -f "$subscription_info_file" ] && grep -q -i "subscription-userinfo:" "$subscription_info_header_tmpfile"; then
 				subscription_info_file="$subscription_info_header_tmpfile"
 			fi
@@ -577,7 +616,7 @@ update_subscription() {
 	fi
 	# download subscription
 	log "Profile" "Download subscription."
-	if curl -s -f -m 120 --connect-timeout 15 --retry 3 -L -X GET -A "$subscription_user_agent" -D "$subscription_header_tmpfile" -o "$subscription_tmpfile" "$subscription_url" > /dev/null 2>&1; then
+	if curl -s -f -m 120 --connect-timeout 15 --retry 3 -L -X GET -A "$subscription_user_agent" $subscription_request_header_arg -D "$subscription_header_tmpfile" -o "$subscription_tmpfile" "$subscription_url" > /dev/null 2>&1; then
 		log "Profile" "Subscription download successful."
 		if [ ! -f "$subscription_info_file" ] && grep -q -i "subscription-userinfo:" "$subscription_header_tmpfile"; then
 			subscription_info_file="$subscription_header_tmpfile"
@@ -633,6 +672,7 @@ update_subscription() {
 		# update subscription file
 		rm -f "$subscription_info_header_tmpfile"
 		rm -f "$subscription_header_tmpfile"
+		rm -f "$subscription_request_header_tmpfile"
 		mv -f "$subscription_tmpfile" "$subscription_file"
 	elif [ "$success" = 0 ]; then
 		log "Profile" "Subscription update failed."
@@ -641,6 +681,7 @@ update_subscription() {
 		# remove tmpfile
 		rm -f "$subscription_info_header_tmpfile"
 		rm -f "$subscription_header_tmpfile"
+		rm -f "$subscription_request_header_tmpfile"
 		rm -f "$subscription_tmpfile"
 	fi
 	uci_commit "nikki"


### PR DESCRIPTION
## Summary

Implements the approach described by @morytyann in #858:

> The only way I can accept is to let users fill in custom request headers by themselves.

This PR adds a generic, user-filled list of HTTP request headers for subscription downloads. There is **no HWID-specific logic**: users whose panels require identification headers (`x-hwid` etc., see #781, #806, #858) fill them in themselves, and proxy providers can document what to fill in.

The field is labelled `HWID Headers` since that is the practical use case, but the code path is generic — the headers are passed to curl as-is. Happy to rename it back to `HTTP Header` if you prefer neutral wording.

Related: #781 #806 #858

## Changes

- **nikki**: new optional `list header` in subscription sections. Headers are written to a temp file (`$TEMP_DIR/<section>.request.header`) and passed to both curl calls (`info_url` and `url`) via `-H @file`, so values containing spaces and colons are handled safely without `eval`. The temp file is cleaned up together with the other temp files in both success and failure branches.
- **luci-app-nikki**: `HWID Headers` DynamicList in the subscription modal — the same stock widget used by the other list options in this app.
- **i18n**: msgid added to the template; ru, zh_Hans and zh_Hant translations included.

## Backward compatibility

- Option absent or empty → the header file is not created, no extra argument is passed, and the curl invocations are **byte-identical** to the current behaviour. No migration needed, existing configs are unaffected.
- The append helper deduplicates identical lines (`grep -qxF`): `update_subscription` runs after `config_load nikki` was already executed in `start_service`, and a repeated `config_load` of the same package duplicates list items — without the guard each header would be sent twice.

## Input validation

Header values never pass through a shell (`-H @file`, no `eval`), so shell injection is not possible. To also prevent HTTP header injection, the append helper rejects values containing CR/LF, requires the `^[A-Za-z0-9-]+:[ -~]*$` shape (header name + printable ASCII), rejects hop-by-hop and framing headers (`host`, `content-length`, `transfer-encoding`, `connection`, `upgrade`, `expect`, `te`, `trailer`, `proxy-*`) and `user-agent` (covered by the dedicated field), and skips duplicate header names. Only the header name is logged when an entry is skipped, so values are never written to the log. The temp file is created with `umask 077`, since headers may carry credentials.

The LuCI field mirrors these rules via `validate()` for immediate feedback; the init script stays the enforcement point, as uci can also be edited from the CLI.

Note: `-H @file` requires curl >= 7.55, which OpenWrt has shipped since 19.07.

## Testing

Tested on a real device: OpenWrt 25.12 (Cudy WR3000P v1), Nikki 1.26.1, Remnawave-based panel with HWID device tracking.

1. Configured headers via LuCI and via uci:

```sh
    uci add_list 'nikki.<section>.header=x-hwid: <id>'
    uci add_list 'nikki.<section>.header=x-device-os: OpenWrt'
    uci add_list 'nikki.<section>.header=x-ver-os: 25.12'
    uci add_list 'nikki.<section>.header=x-device-model: Cudy WR3000P v1'
```

2. `service nikki restart` → subscription update succeeds (`success='1'`), the panel registers the device with correct Platform / OS version / model / User-Agent (screenshots below).
3. Verified the header temp file contains exactly one line per configured header (no duplicates from the double `config_load`).
4. Regression check: removed all `header` entries → update succeeds, curl arguments identical to stock.
5. Manual `Update` button in LuCI (rpcd path) works as well.
6. Validation, LuCI side: non-ASCII input, entries without a colon, reserved headers (`Host`, `Content-Length`) and duplicate header names are all rejected with an inline error; valid entries are accepted and saved.
7. Validation, init side: the same cases are skipped with a log line (`Skip invalid request header`, `Skip reserved request header`, `Skip duplicate request header`, `Skip request header containing line break`), while the subscription still updates successfully.
8. `sh -n` and busybox `ash -n` pass on the init script; `node --check` passes on the LuCI view; the page renders without console errors.

Screenshots:

<img width="1909" height="194" alt="Terminal" src="https://github.com/user-attachments/assets/95b8a3ae-c9b9-4f00-b26b-57af1cab57ad" />
<img width="1646" height="561" alt="Terminal2" src="https://github.com/user-attachments/assets/a7e6cd79-3221-47f4-afd1-a126bc008f54" />
<img width="1790" height="1079" alt="LuCI-App" src="https://github.com/user-attachments/assets/e154dcdd-92d7-4e7f-b4f8-398d9822c1e5" />
<img width="1826" height="982" alt="LuCI-Nikki" src="https://github.com/user-attachments/assets/c1319e0e-053d-44bd-9897-7f0a264077a1" />
<img width="1766" height="714" alt="LuCI-Nikki2" src="https://github.com/user-attachments/assets/bb4f8aff-8154-4774-b925-15e748fa96bf" />
<img width="1799" height="864" alt="LuCI-Profile" src="https://github.com/user-attachments/assets/dbacf2c9-949b-4919-81b8-a7967b1aecef" />
<img width="1919" height="1079" alt="Subs" src="https://github.com/user-attachments/assets/d6ebe933-03e5-44d7-b5a9-1df6be7d84ef" />
<img width="1240" height="450" alt="image" src="https://github.com/user-attachments/assets/63d06c1e-70cf-4a2f-9c68-3e36b430cf1f" />
<img width="1718" height="612" alt="Panel Remnawave" src="https://github.com/user-attachments/assets/4ad50826-58f9-4c02-ba9a-92267620505f" />