### PR TITLE
修复：writefile() 在 8KB 分块边界处可能切断多字节 UTF-8 字符

### DIFF
--- a/luci-app-nikki/htdocs/luci-static/resources/tools/nikki.js
+++ b/luci-app-nikki/htdocs/luci-static/resources/tools/nikki.js
@@ -109,7 +109,6 @@ return baseclass.extend({
         mode = (mode != null) ? mode : 0o644;
 
         const encoder = new TextEncoder();
-        const decoder = new TextDecoder();
         const chunkSize = 8 * 1024;
 
         const bytes = encoder.encode(data);
@@ -118,15 +117,29 @@ return baseclass.extend({
             return callFileWrite(path, data, false, mode);
         }
 
+        // 分块时绝不能把一个多字节 UTF-8 字符切断在两块中间。
+        // 下面每个分块的边界都会往回检查，退到一个完整字符的边界为止，
+        // 这样每一块都能独立、正确地解码，不再依赖后端是如何
+        // 分次 append 写入这些分块的。
+        const decoder = new TextDecoder('utf-8');
         let promise = Promise.resolve();
-        for(let offset = 0; offset < bytes.length; offset += chunkSize) {
-            const chunkStart = offset;
-            const chunkEnd = Math.min(offset + chunkSize, bytes.length);
-            const isLastChunk = chunkEnd === bytes.length;
-            const chunkBytes = bytes.slice(chunkStart, chunkEnd);
-            const chunk = decoder.decode(chunkBytes, { stream: !isLastChunk });
+        let offset = 0;
+
+        while (offset < bytes.length) {
+            let end = Math.min(offset + chunkSize, bytes.length);
+
+            // 只要 `end` 位置的字节是 UTF-8 续字节（10xxxxxx），
+            // 说明这一刀切在了某个字符中间，就继续往前退一位。
+            if (end < bytes.length) {
+                while (end > offset && (bytes[end] & 0xC0) === 0x80) {
+                    end--;
+                }
+            }
+
+            const chunk = decoder.decode(bytes.slice(offset, end));
             const append = offset > 0;
             promise = promise.then(() => callFileWrite(path, chunk, append, mode));
+            offset = end;
         }
 
         return promise;


### PR DESCRIPTION
问题描述

nikki.js 里的 writefile() 函数在保存大文件时，会把内容按 8192 字节
（8 * 1024）切成多块，依次通过 callFileWrite(path, chunk, append, mode)
发送给后端写入：

js
const chunkBytes = bytes.slice(chunkStart, chunkEnd);
const chunk = decoder.decode(chunkBytes, { stream: !isLastChunk });

bytes.slice() 是按固定字节数去切割已编码的 UTF-8 字节数组的，完全不
判断这一刀是否切在了某个字符的中间。如果切割点恰好落在一个多字节字符
（比如中文字符，UTF-8 下占 3 字节）的中间，这一块内容就会被切坏——实际
表现就是保存后的文件里出现 ??? / 乱码字符，而且每次都精确出现在同一
个字节偏移量上（8192 的整数倍），只要同样的内容在同样的位置跨越这个
边界，就会稳定复现。

复现步骤
打开内置的配置文件编辑器（editor.js → 调用 nikki.writefile()）。
载入/粘贴一份总字节数超过 8192 字节的 YAML 配置，并且其中恰好有一个
多字节字符（如中文）横跨第 8192 字节（或它的整数倍）这个位置。
保存。
重新打开这个文件——会发现正好在那个字节位置的字符变成了乱码，而文件
里其它位置出现的完全相同的字符（因为字节偏移量不同，没有跨越边界）
却是正常的。

这说明乱码是跟"分块边界"这个位置绑定的，跟字符本身或者浏览器/系统语言
环境都没有关系。

根本原因

分块的切割点纯粹是按字节数算出来的，完全可能切在字符中间。代码里虽然
给 TextDecoder 传了 { stream: !isLastChunk }，想借助它的流式解码状态
把跨块的字符重新拼起来，但从实际测试结果看，这个机制在"多次调用
callFileWrite 并以 append 方式依次写入"这条链路里并没有真正生效，
被切开的字符最终还是在落盘的文件里变成了乱码。

修复方案

不再依赖 TextDecoder 跨多次调用去维持解码状态，而是在计算每个分块的
切割点时，往回检查：如果这个切割点（非最后一块的情况下）落在一个
UTF-8 续字节（即 (byte & 0xC0) === 0x80）上，就说明切在了字符中间，
于是往前退一位，直到退到一个完整字符的边界为止。这样每一块内容都能
独立解码成完整、合法的字符串，不会再有任何字符被拆分到两次
callFileWrite 调用里。

测试情况
用一份实际的配置文件（约 16KB，中英文混排的 YAML）做了验证：修复前，
文件里有一个中文字符恰好精确落在第 8192 字节这个边界上，每次保存都
稳定复现乱码；修复后反复保存多次，内容都不再出现乱码，并且做了逐字节
扫描，确认所有会被发送出去的分块中，没有任何一个多字节字符跨越
8192 字节的边界。
打过补丁的文件用 node --check 做了语法检查，没有问题。
补充说明
这个问题只会在配置文件大于 8KB 时触发（走单块直接写入的情况不受影响）。
如果维护者希望换一种实现方式（比如按字符/码点而不是按裸字节去切割
data 字符串），我很乐意按项目习惯的写法调整，欢迎讨论。

PS：我用Claude修复的！