### PR TITLE
fix(rpcd): use TLS listen address for API requests when configured

### DIFF
--- a/luci-app-nikki/root/usr/share/rpcd/ucode/luci.nikki
+++ b/luci-app-nikki/root/usr/share/rpcd/ucode/luci.nikki
@@ -82,7 +82,7 @@ const methods = {
 
 			const protocol = api_tls_listen ? 'https' : 'http';
 
-			const url = api_listen + path;
+			const url = (api_tls_listen ?? api_listen) + path;
 
 			const process = popen(`curl --proto-default '${protocol}' --insecure --request '${method}' --oauth2-bearer '${api_secret}' --url-query '${query}' --data '${body}' '${url}'`);
 			if (process) {


### PR DESCRIPTION
## What
The `api` rpcd method picks the protocol ('https') from `external-controller-tls` but always builds the request URL from `external-controller`. In a TLS-only configuration `external-controller` is unset, so the URL becomes `null<path>` and every API call (e.g. dashboard upgrade) fails. Build the URL from `api_tls_listen` when present, matching the protocol selection and the behavior of the frontend `openDashboard` helper.

## Why
This change resolves the target issue or improvement.

## How to test
Verify that the project builds/runs correctly and the specific bug/improvement is addressed.

