### PR TITLE
feat: bundle GeoX data for first startup

### DIFF
--- a/.github/workflows/build-packages.yml
+++ b/.github/workflows/build-packages.yml
@@ -60,7 +60,7 @@ jobs:
         env:
           ARCH: ${{ matrix.arch }}-${{ matrix.branch }}
           FEEDNAME: nikki
-          PACKAGES: mihomo-alpha mihomo-meta nikki luci-app-nikki
+          PACKAGES: mihomo-alpha mihomo-meta nikki-geodata nikki luci-app-nikki
           NO_REFRESH_CHECK: true
 
       - name: upload

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -64,7 +64,7 @@ jobs:
         env:
           ARCH: ${{ matrix.arch }}-${{ matrix.branch }}
           FEEDNAME: nikki
-          PACKAGES: mihomo-alpha mihomo-meta nikki luci-app-nikki
+          PACKAGES: mihomo-alpha mihomo-meta nikki-geodata nikki luci-app-nikki
           INDEX: 1
           KEY_BUILD: ${{ secrets.KEY_BUILD }}
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ English | [中文](README.zh.md)
 
 Transparent Proxy with Mihomo on OpenWrt.
 
+The Nikki package includes the GeoSite and MetaDB GeoIP data required by Mihomo, so its first start does not need to download GeoX files from GitHub.
+
 ## Prerequisites
 
 - OpenWrt >= 24.10
@@ -97,6 +99,7 @@ The package files will be found under `bin/packages/your_architecture/nikki`.
 - kmod-nft-tproxy
 - kmod-tun
 - kmod-dummy
+- nikki-geodata
 
 ## Contributors
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -6,6 +6,8 @@
 
 在 OpenWrt 上使用 Mihomo 进行透明代理。
 
+Nikki 软件包已包含 Mihomo 所需的 GeoSite 和 MetaDB GeoIP 数据，首次启动无需从 GitHub 下载 GeoX 文件。
+
 ## 环境要求
 
 - OpenWrt >= 24.10
@@ -97,6 +99,7 @@ make package/luci-app-nikki/compile
 - kmod-nft-tproxy
 - kmod-tun
 - kmod-dummy
+- nikki-geodata
 
 ## 贡献者
 

--- a/install.sh
+++ b/install.sh
@@ -46,8 +46,9 @@ if [ -x "/bin/opkg" ]; then
 	wget -O nikki.version $feed_url/index.json
 	# install ipks
 	echo "install ipks"
-	eval "$(jsonfilter -i nikki.version -e "mihomo_meta_version=@['packages']['mihomo-meta']" -e "nikki_version=@['packages']['nikki']" -e "luci_app_nikki_version=@['packages']['luci-app-nikki']")"
+	eval "$(jsonfilter -i nikki.version -e "mihomo_meta_version=@['packages']['mihomo-meta']" -e "nikki_geodata_version=@['packages']['nikki-geodata']" -e "nikki_version=@['packages']['nikki']" -e "luci_app_nikki_version=@['packages']['luci-app-nikki']")"
 	opkg install "$feed_url/mihomo-meta_${mihomo_meta_version}_${arch}.ipk"
+	opkg install "$feed_url/nikki-geodata_${nikki_geodata_version}_all.ipk"
 	opkg install "$feed_url/nikki_${nikki_version}_${arch}.ipk"
 	opkg install "$feed_url/luci-app-nikki_${luci_app_nikki_version}_all.ipk"
 	for lang in $languages; do
@@ -65,7 +66,7 @@ elif [ -x "/usr/bin/apk" ]; then
 	languages=$(apk list --installed --manifest luci-i18n-base-* | cut -d ' ' -f 1 | cut -d '-' -f 4-)
 	# install apks from remote repository
 	echo "install apks from remote repository"
-	apk add --allow-untrusted -X $feed_url/packages.adb mihomo-meta nikki luci-app-nikki
+	apk add --allow-untrusted -X $feed_url/packages.adb mihomo-meta nikki-geodata nikki luci-app-nikki
 	for lang in $languages; do
 		apk add --allow-untrusted -X $feed_url/packages.adb "luci-i18n-nikki-${lang}"
 	done

--- a/nikki-geodata/Makefile
+++ b/nikki-geodata/Makefile
@@ -1,0 +1,57 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=nikki-geodata
+PKG_VERSION:=2026.08.13
+PKG_RELEASE:=1
+
+PKG_LICENSE:=GPL-3.0-only
+PKG_MAINTAINER:=Joseph Mory <morytyann@gmail.com>
+
+include $(INCLUDE_DIR)/package.mk
+
+GEODATA_SOURCE_VERSION:=4d8b283b57903e4dd33a9e5a994b6452aac2d21d
+GEOSITE_FILE:=geosite.dat.$(PKG_VERSION)
+GEOIP_FILE:=geoip.metadb.$(PKG_VERSION)
+
+define Download/geosite
+  URL:=https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/$(GEODATA_SOURCE_VERSION)/
+  URL_FILE:=geosite.dat
+  FILE:=$(GEOSITE_FILE)
+  HASH:=e108d9623564b3e7aba740e1ce83f9adc62720b36f09c04ef076eaf2a818364c
+endef
+
+define Download/geoip
+  URL:=https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/$(GEODATA_SOURCE_VERSION)/
+  URL_FILE:=geoip.metadb
+  FILE:=$(GEOIP_FILE)
+  HASH:=b930c12c5cfd255d5bb3bac219a6de7fb36bddb9123d476ba3c8a277e36a410e
+endef
+
+define Package/nikki-geodata
+  SECTION:=net
+  CATEGORY:=Network
+  TITLE:=GeoX data for Nikki
+  URL:=https://github.com/MetaCubeX/meta-rules-dat
+  PKGARCH:=all
+endef
+
+define Package/nikki-geodata/description
+  GeoSite and MetaDB GeoIP data for Mihomo running under Nikki.
+endef
+
+define Build/Prepare
+	$(call Build/Prepare/Default)
+	$(call Download,geosite)
+	$(call Download,geoip)
+endef
+
+define Build/Compile
+endef
+
+define Package/nikki-geodata/install
+	$(INSTALL_DIR) $(1)/etc/nikki/run
+	$(INSTALL_DATA) $(DL_DIR)/$(GEOSITE_FILE) $(1)/etc/nikki/run/GeoSite.dat
+	$(INSTALL_DATA) $(DL_DIR)/$(GEOIP_FILE) $(1)/etc/nikki/run/geoip.metadb
+endef
+
+$(eval $(call BuildPackage,nikki-geodata))

--- a/nikki/Makefile
+++ b/nikki/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nikki
 PKG_VERSION:=2026.04.08
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=GPL3.0+
 PKG_MAINTAINER:=Joseph Mory <morytyann@gmail.com>
@@ -14,7 +14,7 @@ define Package/nikki
   CATEGORY:=Network
   TITLE:=Transparent Proxy with Mihomo on OpenWrt.
   URL:=https://github.com/nikkinikki-org
-  DEPENDS:=+ca-bundle +curl +yq firewall4 +ip-full +kmod-inet-diag +kmod-nft-socket +kmod-nft-tproxy +kmod-tun +kmod-dummy +mihomo
+  DEPENDS:=+ca-bundle +curl +yq firewall4 +ip-full +kmod-inet-diag +kmod-nft-socket +kmod-nft-tproxy +kmod-tun +kmod-dummy +mihomo +nikki-geodata
 endef
 
 define Package/nikki/conffiles

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -7,11 +7,13 @@ if [ -x "/bin/opkg" ]; then
 	opkg list-installed luci-i18n-nikki-* | cut -d ' ' -f 1 | xargs opkg remove
 	opkg remove luci-app-nikki
 	opkg remove nikki
+	opkg remove nikki-geodata
 	opkg remove mihomo-meta mihomo-alpha
 elif [ -x "/usr/bin/apk" ]; then
 	apk list --installed --manifest luci-i18n-nikki-* | cut -d ' ' -f 1 | xargs apk del
 	apk del luci-app-nikki
 	apk del nikki
+	apk del nikki-geodata
 	apk del mihomo-meta mihomo-alpha
 fi
 # remove config


### PR DESCRIPTION
## Summary

- add an architecture-independent `nikki-geodata` package
- install pinned GeoSite and MetaDB GeoIP data into `/etc/nikki/run`
- make `nikki` depend on the data package so Mihomo does not download GeoX files on first startup
- include the package in opkg/apk installation, removal, and release workflows

## Packaging details

The data is downloaded at build time from a pinned `MetaCubeX/meta-rules-dat` commit and verified with SHA-256 checksums. This keeps builds reproducible without committing approximately 13 MB of generated data to this repository. The installed files remain writable so Mihomo can replace them through its normal GeoX update mechanism.

## Validation

- verified both pinned assets against their declared SHA-256 hashes
- passed `sh -n` for the affected shell scripts
- parsed both modified GitHub Actions workflows as YAML
- passed `git diff --check`

A full ipk/apk build was not run because this checkout is not inside an OpenWrt SDK.