### PR TITLE
feat: reuse system GeoData on startup / 启动时复用系统 GeoData

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ English | [中文](README.zh.md)
 
 Transparent Proxy with Mihomo on OpenWrt.
 
+On startup, Nikki reuses `geoip.dat` and `geosite.dat` from `/usr/share/v2ray` or `/usr/share/xray` before Mihomo tries its configured GeoX download URLs. The bundled Mihomo packages keep these files shared until an update is available, then replace the links with Nikki-owned files without modifying the shared data. Third-party Mihomo packages safely fall back to copying the files.
+
 ## Prerequisites
 
 - OpenWrt >= 24.10

--- a/README.zh.md
+++ b/README.zh.md
@@ -6,6 +6,8 @@
 
 在 OpenWrt 上使用 Mihomo 进行透明代理。
 
+启动时，Nikki 会在 Mihomo 尝试其配置的 GeoX 下载地址之前，优先复用 `/usr/share/v2ray` 或 `/usr/share/xray` 中的 `geoip.dat` 和 `geosite.dat`。仓库内置的 Mihomo 软件包会保持软链，直到发现更新后再将其替换为 Nikki 自有文件，且不会修改共享数据；第三方 Mihomo 软件包则安全降级为复制文件。
+
 ## 环境要求
 
 - OpenWrt >= 24.10

--- a/mihomo-alpha/Makefile
+++ b/mihomo-alpha/Makefile
@@ -2,6 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mihomo-alpha
 PKG_VERSION:=2026.07.08
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
@@ -49,6 +50,8 @@ endef
 
 define Package/mihomo-alpha/install
 	$(call GoPackage/Package/Install/Bin,$(1))
+	$(INSTALL_DIR) $(1)/usr/share/mihomo
+	touch $(1)/usr/share/mihomo/geodata-symlink-cow
 endef
 
 define Build/Prepare

--- a/mihomo-alpha/patches/010-geodata-symlink-copy-on-write.patch
+++ b/mihomo-alpha/patches/010-geodata-symlink-copy-on-write.patch
@@ -1,0 +1,48 @@
+--- a/component/updater/update_geo.go
++++ b/component/updater/update_geo.go
+@@ -7,0 +8 @@ import (
++	"path/filepath"
+@@ -46,0 +48,37 @@ func SetGeoUpdateInterval(newGeoUpdateInterval int) {
++// writeGeoData preserves shared GeoData while it is unchanged. When an update
++// is available, atomically replace the symlink itself with a local regular file
++// instead of following the link and overwriting another package's data.
++func writeGeoData(vehicle *resource.HTTPVehicle, data []byte) error {
++	path := vehicle.Path()
++	fileInfo, err := os.Lstat(path)
++	if err != nil || fileInfo.Mode()&os.ModeSymlink == 0 {
++		return vehicle.Write(data)
++	}
++
++	mode := os.FileMode(0o644)
++	if targetInfo, err := os.Stat(path); err == nil {
++		mode = targetInfo.Mode().Perm()
++	}
++
++	tempFile, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-*")
++	if err != nil {
++		return err
++	}
++	tempPath := tempFile.Name()
++	defer func() {
++		_ = tempFile.Close()
++		_ = os.Remove(tempPath)
++	}()
++
++	if err = tempFile.Chmod(mode); err != nil {
++		return err
++	}
++	if _, err = tempFile.Write(data); err != nil {
++		return err
++	}
++	if err = tempFile.Close(); err != nil {
++		return err
++	}
++	return os.Rename(tempPath, path)
++}
++
+@@ -133 +171 @@ func UpdateGeoIp() (err error) {
+-	if err = vehicle.Write(data); err != nil {
++	if err = writeGeoData(vehicle, data); err != nil {
+@@ -163 +201 @@ func UpdateGeoSite() (err error) {
+-	if err = vehicle.Write(data); err != nil {
++	if err = writeGeoData(vehicle, data); err != nil {

--- a/mihomo-meta/Makefile
+++ b/mihomo-meta/Makefile
@@ -2,6 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=mihomo-meta
 PKG_VERSION:=1.19.29
+PKG_RELEASE:=2
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
@@ -50,6 +51,8 @@ endef
 
 define Package/mihomo-meta/install
 	$(call GoPackage/Package/Install/Bin,$(1))
+	$(INSTALL_DIR) $(1)/usr/share/mihomo
+	touch $(1)/usr/share/mihomo/geodata-symlink-cow
 endef
 
 define Build/Prepare

--- a/mihomo-meta/patches/010-geodata-symlink-copy-on-write.patch
+++ b/mihomo-meta/patches/010-geodata-symlink-copy-on-write.patch
@@ -1,0 +1,48 @@
+--- a/component/updater/update_geo.go
++++ b/component/updater/update_geo.go
+@@ -7,0 +8 @@ import (
++	"path/filepath"
+@@ -46,0 +48,37 @@ func SetGeoUpdateInterval(newGeoUpdateInterval int) {
++// writeGeoData preserves shared GeoData while it is unchanged. When an update
++// is available, atomically replace the symlink itself with a local regular file
++// instead of following the link and overwriting another package's data.
++func writeGeoData(vehicle *resource.HTTPVehicle, data []byte) error {
++	path := vehicle.Path()
++	fileInfo, err := os.Lstat(path)
++	if err != nil || fileInfo.Mode()&os.ModeSymlink == 0 {
++		return vehicle.Write(data)
++	}
++
++	mode := os.FileMode(0o644)
++	if targetInfo, err := os.Stat(path); err == nil {
++		mode = targetInfo.Mode().Perm()
++	}
++
++	tempFile, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-*")
++	if err != nil {
++		return err
++	}
++	tempPath := tempFile.Name()
++	defer func() {
++		_ = tempFile.Close()
++		_ = os.Remove(tempPath)
++	}()
++
++	if err = tempFile.Chmod(mode); err != nil {
++		return err
++	}
++	if _, err = tempFile.Write(data); err != nil {
++		return err
++	}
++	if err = tempFile.Close(); err != nil {
++		return err
++	}
++	return os.Rename(tempPath, path)
++}
++
+@@ -133 +171 @@ func UpdateGeoIp() (err error) {
+-	if err = vehicle.Write(data); err != nil {
++	if err = writeGeoData(vehicle, data); err != nil {
+@@ -163 +201 @@ func UpdateGeoSite() (err error) {
+-	if err = vehicle.Write(data); err != nil {
++	if err = writeGeoData(vehicle, data); err != nil {

--- a/nikki/Makefile
+++ b/nikki/Makefile
@@ -2,7 +2,7 @@ include $(TOPDIR)/rules.mk
 
 PKG_NAME:=nikki
 PKG_VERSION:=2026.04.08
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_LICENSE:=GPL3.0+
 PKG_MAINTAINER:=Joseph Mory <morytyann@gmail.com>

--- a/nikki/files/nikki.init
+++ b/nikki/files/nikki.init
@@ -54,6 +54,12 @@ start_service() {
 		log "App" "Exit."
 		return
 	fi
+	# use system GeoData before Mihomo tries its configured download URLs
+	if ! prepare_geodata; then
+		log "App" "Failed to prepare GeoData."
+		log "App" "Exit."
+		return
+	fi
 	# get config
 	## app config
 	local scheduled_restart scheduled_restart_cron profile test_profile core_only

--- a/nikki/files/scripts/include.sh
+++ b/nikki/files/scripts/include.sh
@@ -10,6 +10,13 @@ RUN_PROFILE_PATH="$RUN_DIR/config.yaml"
 PROVIDERS_DIR="$RUN_DIR/providers"
 RULE_PROVIDERS_DIR="$PROVIDERS_DIR/rule"
 PROXY_PROVIDERS_DIR="$PROVIDERS_DIR/proxy"
+GEOIP_DAT_PATH="$RUN_DIR/GeoIP.dat"
+GEOSITE_DAT_PATH="$RUN_DIR/GeoSite.dat"
+
+# shared geodata
+V2RAY_GEODATA_DIR="/usr/share/v2ray"
+XRAY_GEODATA_DIR="/usr/share/xray"
+MIHOMO_GEODATA_SYMLINK_COW_PATH="/usr/share/mihomo/geodata-symlink-cow"
 
 # log
 LOG_DIR="/var/log/nikki"
@@ -78,6 +85,61 @@ prepare_files() {
 	if [ ! -d "$TEMP_DIR" ]; then
 		mkdir -p "$TEMP_DIR"
 	fi
+}
+
+prepare_geodata_file() {
+	local target; target="$1"
+	local filename; filename="$2"
+
+	# Keep Nikki-owned data. A symlink is only safe when the active Mihomo
+	# package advertises copy-on-write support for GeoData updates.
+	if [ -s "$target" ]; then
+		if [ -L "$target" ] && [ ! -f "$MIHOMO_GEODATA_SYMLINK_COW_PATH" ]; then
+			local tmpfile; tmpfile="$target.tmp.$$"
+			if cp -fpL "$target" "$tmpfile" && mv -f "$tmpfile" "$target"; then
+				log "GeoX" "Convert unsupported symlink to local file: $target."
+				return 0
+			fi
+			rm -f "$tmpfile"
+			log "GeoX" "Failed to convert unsupported symlink: $target."
+			return 1
+		fi
+		return 0
+	fi
+
+	# Remove an empty file or a dangling symlink so a usable shared file can
+	# replace it, or Mihomo can fall back to its configured download URL.
+	if [ -e "$target" ] || [ -L "$target" ]; then
+		rm -f "$target"
+	fi
+
+	local source
+	for source in "$V2RAY_GEODATA_DIR/$filename" "$XRAY_GEODATA_DIR/$filename"; do
+		[ -s "$source" ] || continue
+		if [ -f "$MIHOMO_GEODATA_SYMLINK_COW_PATH" ]; then
+			if ln -s "$source" "$target"; then
+				log "GeoX" "Use shared file: $source."
+				return 0
+			fi
+		else
+			if cp -fp "$source" "$target"; then
+				log "GeoX" "Copy shared file for unpatched core: $source."
+				return 0
+			fi
+		fi
+		log "GeoX" "Failed to use shared file: $source."
+	done
+
+	return 0
+}
+
+prepare_geodata() {
+	if ! mkdir -p "$RUN_DIR"; then
+		log "GeoX" "Failed to prepare run directory."
+		return 1
+	fi
+	prepare_geodata_file "$GEOIP_DAT_PATH" "geoip.dat" || return 1
+	prepare_geodata_file "$GEOSITE_DAT_PATH" "geosite.dat" || return 1
 }
 
 log() {


### PR DESCRIPTION
## Summary / 概述

Reuse GeoIP and GeoSite data already installed by V2Ray or Xray before Mihomo falls back to its configured GeoX download URLs.

在 Mihomo 回退到配置的 GeoX 下载地址之前，优先复用系统中 V2Ray 或 Xray 已安装的 GeoIP 和 GeoSite 数据。

## Behavior / 行为

- Keep an existing non-empty Nikki cache unchanged.
- Search `/usr/share/v2ray` first, then `/usr/share/xray`, independently for `geoip.dat` and `geosite.dat`.
- With the bundled patched Mihomo packages, link shared files into `/etc/nikki/run` so the first start does not duplicate or download them.
- When remote content changes, atomically replace the symlink with a Nikki-owned regular file instead of overwriting the shared source.
- If the remote hash is unchanged, retain the symlink.
- Safely copy shared files when an unpatched third-party Mihomo package is installed.
- Preserve the existing `geox-url`, `geo-auto-update`, and `geo-update-interval` behavior.

- 保留 Nikki 已有的非空缓存文件。
- 分别查找 `geoip.dat` 和 `geosite.dat`，优先 `/usr/share/v2ray`，其次 `/usr/share/xray`。
- 使用仓库内已打补丁的 Mihomo 软件包时，将共享文件软链到 `/etc/nikki/run`，首次启动无需重复存储或联网下载。
- 远端内容发生变化时，原子替换软链为 Nikki 自有普通文件，而不是覆盖共享源文件。
- 远端哈希未变化时继续保留软链。
- 使用未打补丁的第三方 Mihomo 时，安全降级为复制共享文件。
- 保持现有 `geox-url`、`geo-auto-update` 和 `geo-update-interval` 行为不变。

## Validation / 验证

- POSIX `sh -n` and BusyBox `ash` syntax checks passed.
- Startup behavior tests passed for V2Ray priority, per-file Xray fallback, existing-cache retention, dangling-link recovery, third-party-core copying, core switching, and native download fallback.
- Both Mihomo patches apply with zero fuzz to the pinned Meta and Alpha source revisions.
- `git diff --check` passed.

- POSIX `sh -n` 与 BusyBox `ash` 语法检查通过。
- 已验证 V2Ray 优先、按文件回退 Xray、保留已有缓存、恢复失效软链、第三方核心复制降级、核心切换以及原生下载回退。
- 两份 Mihomo 补丁均能以零 fuzz 应用于仓库锁定的 Meta 和 Alpha 源码版本。
- `git diff --check` 通过。

Full OpenWrt package compilation was not run locally because an OpenWrt SDK and Go toolchain were not available in the current environment.

由于当前环境没有 OpenWrt SDK 和 Go 工具链，未在本地执行完整的软件包编译。
