### PR TITLE
docs: TPROXY requires net.ipv4.conf.all.src_valid_mark=0 (Tailscale conflict causes silent packet drops)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ Transparent Proxy with Mihomo on OpenWrt.
 - OpenWrt >= 24.10
 - Linux Kernel >= 5.13
 - firewall4
+- For TPROXY mode: `net.ipv4.conf.all.src_valid_mark` must be `0` (the kernel uses `max(conf/all, conf/<iface>)`)
+
+> **Note**: Some software (e.g. Tailscale 1.98+, which defaults to `NetfilterMode=on`) sets
+> `net.ipv4.conf.all.src_valid_mark` to `1` on startup. In TPROXY mode this makes **all LAN clients
+> lose Internet access** (DNS still works and the router itself is fine), while app/core/firewall
+> logs and counters show nothing unusual, which makes it very hard to diagnose.
+> Fix: `tailscale set --netfilter-mode=off` and reboot, or `sysctl -w net.ipv4.conf.all.src_valid_mark=0`.
+>
+> See the [FAQ](https://github.com/nikkinikki-org/OpenWrt-nikki/wiki/FAQ) for details.
 
 ## Feature
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -11,6 +11,14 @@
 - OpenWrt >= 24.10
 - Linux Kernel >= 5.13
 - firewall4
+- 使用 TPROXY 模式时：`net.ipv4.conf.all.src_valid_mark` 必须为 `0`（内核取 `max(conf/all, conf/<iface>)`）
+
+> **注意**：部分软件（如 Tailscale 1.98+，默认 `NetfilterMode=on`）会在启动时把 `net.ipv4.conf.all.src_valid_mark`
+> 写成 `1`。此时 TPROXY 下**局域网客户端会全部无法上网**（DNS 正常、路由器本机正常），
+> 而插件日志、核心日志与防火墙计数都不会有任何异常，非常难以排查。
+> 解决：`tailscale set --netfilter-mode=off` 后重启，或 `sysctl -w net.ipv4.conf.all.src_valid_mark=0`。
+>
+> 详见 [FAQ](https://github.com/nikkinikki-org/OpenWrt-nikki/wiki/FAQ)。
 
 ## 功能
 


### PR DESCRIPTION
## Background

Related issue: #903 — in **TPROXY** mode **all LAN clients lose Internet access**, while DNS keeps working
and the **router itself is perfectly fine**, and the app log, core log, firewall drop counters and kernel SNMP
counters are **all clean** (no clue at all).

Root cause: another program on the same system — typically **Tailscale 1.98+** (`NetfilterMode=on` by default,
which is what you get from `apk add tailscale`) — writes `net.ipv4.conf.all.src_valid_mark = 1` on startup.
TPROXY relies on the "fwmark + policy routing + local route" scheme, and the two collide inside the kernel's
`fib_validate_source()`:

- the reverse-path lookup of the *source address* also carries the fwmark that the proxy set on the packet
  (because `src_valid_mark=1`), so it hits the proxy's own local route table → `RTN_LOCAL` → `-EINVAL`
  → `goto martian_source` → `ip_handle_martian_source()`;
- that function **only bumps the internal `RT_CACHE_STAT(in_martian_src)` counter** — it touches no
  `/proc/net/snmp` counter and logs nothing by default (`log_martians=0`), so packets vanish without a trace;
- note that `src_valid_mark` is evaluated as `max(conf/all, conf/<iface>)`, so even with
  `br-lan.src_valid_mark=0` a global `conf/all=1` still applies. The kernel documentation for `src_valid_mark`
  literally says *"…utilizing the fwmark in only one direction, e.g., transparent proxying"* for the value `0`.

## What this PR changes

Documentation only, no code:

- `README.md` / `README.zh.md`: add the sysctl requirement to the prerequisites and a short note describing the
  symptom, the cause and the fix, pointing to the Wiki FAQ.

## Minimal reproduction

1. Install Tailscale from the package feed (`apk add tailscale`) and keep its defaults
   (`tailscale debug prefs | grep NetfilterMode` → `2`);
2. Install nikki and enable **TPROXY** (`tcp_mode=tproxy`, `lan_proxy=1`);
3. Access any proxied port from a LAN client → everything times out, while the router itself works fine.

## How to verify

```sh
sysctl -n net.ipv4.conf.all.src_valid_mark        # 1 while broken, must be 0
tailscale set --netfilter-mode=off                # or: sysctl -w net.ipv4.conf.all.src_valid_mark=0
# on a LAN client, download a large file (don't rely on ping or on a successful handshake)
curl -s -o /dev/null -m 30 -w 'size=%{size_download} speed=%{speed_download}\n' \
  https://mirrors.aliyun.com/ubuntu/ls-lR.gz
```

## Notes

GitHub wikis cannot receive pull requests, so the ready-to-paste `FAQ.md` entry is posted as a comment in #903
for the maintainer to copy. If you'd rather keep this out of the README, I'm happy to drop the note and keep
only the prerequisite bullet.
